### PR TITLE
ci: split multi-arch image builds by platform

### DIFF
--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -9,7 +9,8 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
+      merge_matrix: ${{ steps.set-matrix.outputs.merge_matrix }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -53,7 +54,8 @@ jobs:
             return $result
           }
           
-          combinations=()
+          build_combinations=()
+          merge_combinations=()
           # Get available tags and filter out versioned ones
           tags=$(curl -s "https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=100" | \
                 jq -r '.results[].name | select(test("^[0-9]") | not)')
@@ -66,8 +68,13 @@ jobs:
               
               # Get the base digest label stored in our image (if it exists)
               token=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${DOCKERHUB_USERNAME}/nextcloud:pull" | jq -r '.token')
-              our_config=$(curl -s -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              our_config=$(curl -s -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json" \
                 "https://registry-1.docker.io/v2/${DOCKERHUB_USERNAME}/nextcloud/manifests/$tag" 2>/dev/null)
+              manifest_digest=$(echo "$our_config" | jq -r '.manifests[0].digest // ""')
+              if [[ -n "$manifest_digest" && "$manifest_digest" != "null" ]]; then
+                our_config=$(curl -s -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json" \
+                  "https://registry-1.docker.io/v2/${DOCKERHUB_USERNAME}/nextcloud/manifests/$manifest_digest" 2>/dev/null)
+              fi
               config_digest=$(echo "$our_config" | jq -r '.config.digest // ""')
               
               stored_base_digest=""
@@ -99,7 +106,11 @@ jobs:
                 
                 if [ ${#supported_archs[@]} -gt 0 ]; then
                   platforms=$(IFS=,; echo "${supported_archs[*]}")
-                  combinations+=("{\"tag\":\"$tag\",\"platforms\":\"$platforms\",\"base_digest\":\"$base_digest\"}")
+                  merge_combinations+=("{\"tag\":\"$tag\",\"platforms\":\"$platforms\",\"base_digest\":\"$base_digest\"}")
+                  for arch in "${supported_archs[@]}"; do
+                    platform_slug="${arch//\//-}"
+                    build_combinations+=("{\"tag\":\"$tag\",\"platform\":\"$arch\",\"platform_slug\":\"$platform_slug\",\"base_digest\":\"$base_digest\"}")
+                  done
                   echo "  → $tag: ${#supported_archs[@]} architectures"
                 else
                   echo "  → $tag: No supported architectures, skipping"
@@ -107,15 +118,17 @@ jobs:
               fi
             fi
           done
-          echo "matrix={\"include\":[$(IFS=,; echo "${combinations[*]}")]}" >> $GITHUB_OUTPUT
+          echo "build_matrix={\"include\":[$(IFS=,; echo "${build_combinations[*]}")]}" >> $GITHUB_OUTPUT
+          echo "merge_matrix={\"include\":[$(IFS=,; echo "${merge_combinations[*]}")]}" >> $GITHUB_OUTPUT
 
   build:
     needs: detect
     runs-on: ubuntu-latest
-    if: ${{ needs.detect.outputs.matrix != '{"include":[]}' && needs.detect.outputs.matrix != '{"include":[,]}' && needs.detect.outputs.matrix != '{"include":[]}' }}
+    if: ${{ needs.detect.outputs.build_matrix != '{"include":[]}' }}
     strategy:
-      matrix: ${{fromJson(needs.detect.outputs.matrix)}}
+      matrix: ${{fromJson(needs.detect.outputs.build_matrix)}}
       fail-fast: false
+      max-parallel: 6
 
     steps:
       - name: Checkout repo
@@ -134,6 +147,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Nextcloud Image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -141,10 +155,67 @@ jobs:
           build-args: |
             IMAGE=nextcloud
             TAG=${{ matrix.tag }}
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud:${{ matrix.tag }}
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/nextcloud,push-by-digest=true,name-canonical=true,push=true
           provenance: false
           sbom: false
           labels: |
             org.opencontainers.image.base.digest=${{ matrix.base_digest }}
+
+      - name: Export image digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.tag }}--${{ matrix.platform_slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [detect, build]
+    runs-on: ubuntu-latest
+    if: ${{ needs.detect.outputs.merge_matrix != '{"include":[]}' }}
+    strategy:
+      matrix: ${{fromJson(needs.detect.outputs.merge_matrix)}}
+      fail-fast: false
+
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.tag }}--*
+          merge-multiple: true
+
+      - name: Create and Push Multi-Arch Manifest
+        env:
+          IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud
+        run: |
+          mapfile -t digest_files < <(find /tmp/digests -type f | sort)
+          if [ ${#digest_files[@]} -eq 0 ]; then
+            echo "No image digests found for ${{ matrix.tag }}"
+            exit 1
+          fi
+
+          refs=()
+          for digest_file in "${digest_files[@]}"; do
+            refs+=("${IMAGE}@sha256:$(basename "$digest_file")")
+          done
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${{ matrix.tag }}" \
+            "${refs[@]}"

--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -205,9 +205,15 @@ jobs:
         env:
           IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud
         run: |
+          IFS=',' read -r -a expected_platforms <<< "${{ matrix.platforms }}"
           mapfile -t digest_files < <(find /tmp/digests -type f | sort)
           if [ ${#digest_files[@]} -eq 0 ]; then
             echo "No image digests found for ${{ matrix.tag }}"
+            exit 1
+          fi
+          if [ ${#digest_files[@]} -ne ${#expected_platforms[@]} ]; then
+            echo "Expected ${#expected_platforms[@]} image digests for ${{ matrix.tag }} (${{ matrix.platforms }}), found ${#digest_files[@]}"
+            printf 'Found digest file: %s\n' "${digest_files[@]}"
             exit 1
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE
-ARG TAG
+ARG IMAGE=nextcloud
+ARG TAG=latest
 
 FROM ${IMAGE}:${TAG}
 


### PR DESCRIPTION
## Summary
- Build each detected tag/platform as an individual pushed digest, then create the DockerHub multi-arch tag from those digests.
- Read stored base-digest labels through manifest-list child manifests so rebuild detection works with multi-arch images.
- Add safe Dockerfile ARG defaults to remove the invalid empty base-image warning seen in the failed job.

## Root cause
The scheduled run failed while building `production-apache` for all Debian platforms in one BuildKit worker. The `linux/s390x`/other emulated package installs exhausted runner disk while unpacking FFmpeg dependencies. Splitting platforms into separate digest builds removes that shared disk pressure and keeps the final published tag multi-arch.

## Test plan
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/nextcloud-docker.yml"); puts "workflow yaml ok"'`\n- Extracted detect and merge run scripts from the workflow and ran `bash -n`.\n- `git diff --check`\n- `docker build --build-arg TAG=production-apache --platform linux/amd64 -t nextcloud-docker-test:production-apache-amd64 .`\n- `docker run --rm nextcloud-docker-test:production-apache-amd64 ffmpeg -version | head -1` -> `ffmpeg version 7.1.4-0+deb13u1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build and publishing workflow to use digest-based artifact approach for improved multi-architecture manifest assembly.
  * Added default values for Dockerfile build arguments (IMAGE: `nextcloud`, TAG: `latest`) for simplified container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->