### PR TITLE
ci: harden and stabilize manifest publishing

### DIFF
--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -163,9 +163,15 @@ jobs:
             org.opencontainers.image.base.digest=${{ matrix.base_digest }}
 
       - name: Export image digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="$DIGEST"
+          if [ -z "$digest" ]; then
+            echo "Build did not produce an image digest"
+            exit 1
+          fi
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload image digest
@@ -204,15 +210,17 @@ jobs:
       - name: Create and Push Multi-Arch Manifest
         env:
           IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud
+          TAG: ${{ matrix.tag }}
+          PLATFORMS: ${{ matrix.platforms }}
         run: |
-          IFS=',' read -r -a expected_platforms <<< "${{ matrix.platforms }}"
+          IFS=',' read -r -a expected_platforms <<< "$PLATFORMS"
           mapfile -t digest_files < <(find /tmp/digests -type f | sort)
           if [ ${#digest_files[@]} -eq 0 ]; then
-            echo "No image digests found for ${{ matrix.tag }}"
+            echo "No image digests found for $TAG"
             exit 1
           fi
           if [ ${#digest_files[@]} -ne ${#expected_platforms[@]} ]; then
-            echo "Expected ${#expected_platforms[@]} image digests for ${{ matrix.tag }} (${{ matrix.platforms }}), found ${#digest_files[@]}"
+            echo "Expected ${#expected_platforms[@]} image digests for $TAG ($PLATFORMS), found ${#digest_files[@]}"
             printf 'Found digest file: %s\n' "${digest_files[@]}"
             exit 1
           fi
@@ -223,5 +231,5 @@ jobs:
           done
 
           docker buildx imagetools create \
-            --tag "${IMAGE}:${{ matrix.tag }}" \
+            --tag "${IMAGE}:${TAG}" \
             "${refs[@]}"

--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -162,23 +162,30 @@ jobs:
           labels: |
             org.opencontainers.image.base.digest=${{ matrix.base_digest }}
 
-      - name: Export image digest
+      - name: Export image descriptor
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          METADATA: ${{ steps.build.outputs.metadata }}
+          PLATFORM_SLUG: ${{ matrix.platform_slug }}
         run: |
-          mkdir -p /tmp/digests
-          digest="$DIGEST"
-          if [ -z "$digest" ]; then
-            echo "Build did not produce an image digest"
+          mkdir -p /tmp/descriptors
+          descriptor_file="/tmp/descriptors/${PLATFORM_SLUG}.json"
+          printf '%s' "$METADATA" | jq -e '."containerimage.descriptor"' > "$descriptor_file"
+          digest=$(jq -r '.digest // ""' "$descriptor_file")
+          media_type=$(jq -r '.mediaType // ""' "$descriptor_file")
+          size=$(jq -r '.size // ""' "$descriptor_file")
+          platform=$(jq -r '.platform | [.os, .architecture, .variant // empty] | join("/")' "$descriptor_file")
+          if [ -z "$digest" ] || [ -z "$media_type" ] || [ -z "$size" ] || [ -z "$platform" ]; then
+            echo "Build did not produce a complete image descriptor"
+            cat "$descriptor_file"
             exit 1
           fi
-          touch "/tmp/digests/${digest#sha256:}"
+          echo "Exported $platform descriptor: $digest"
 
-      - name: Upload image digest
+      - name: Upload image descriptor
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.tag }}--${{ matrix.platform_slug }}
-          path: /tmp/digests/*
+          name: descriptors-${{ matrix.tag }}--${{ matrix.platform_slug }}
+          path: /tmp/descriptors/*.json
           if-no-files-found: error
           retention-days: 1
 
@@ -189,47 +196,74 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.detect.outputs.merge_matrix)}}
       fail-fast: false
+      max-parallel: 1
 
     steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Download image digests
+      - name: Download image descriptors
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests
-          pattern: digests-${{ matrix.tag }}--*
+          path: /tmp/descriptors
+          pattern: descriptors-${{ matrix.tag }}--*
           merge-multiple: true
 
       - name: Create and Push Multi-Arch Manifest
         env:
-          IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          REPOSITORY: ${{ secrets.DOCKERHUB_USERNAME }}/nextcloud
           TAG: ${{ matrix.tag }}
           PLATFORMS: ${{ matrix.platforms }}
         run: |
           IFS=',' read -r -a expected_platforms <<< "$PLATFORMS"
-          mapfile -t digest_files < <(find /tmp/digests -type f | sort)
-          if [ ${#digest_files[@]} -eq 0 ]; then
-            echo "No image digests found for $TAG"
+          mapfile -t descriptor_files < <(find /tmp/descriptors -type f -name '*.json' | sort)
+          if [ ${#descriptor_files[@]} -eq 0 ]; then
+            echo "No image descriptors found for $TAG"
             exit 1
           fi
-          if [ ${#digest_files[@]} -ne ${#expected_platforms[@]} ]; then
-            echo "Expected ${#expected_platforms[@]} image digests for $TAG ($PLATFORMS), found ${#digest_files[@]}"
-            printf 'Found digest file: %s\n' "${digest_files[@]}"
+          if [ ${#descriptor_files[@]} -ne ${#expected_platforms[@]} ]; then
+            echo "Expected ${#expected_platforms[@]} image descriptors for $TAG ($PLATFORMS), found ${#descriptor_files[@]}"
+            printf 'Found descriptor file: %s\n' "${descriptor_files[@]}"
             exit 1
           fi
 
-          refs=()
-          for digest_file in "${digest_files[@]}"; do
-            refs+=("${IMAGE}@sha256:$(basename "$digest_file")")
+          manifest_file=$(mktemp)
+          jq -s '{
+            schemaVersion: 2,
+            mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
+            manifests: .
+          }' "${descriptor_files[@]}" > "$manifest_file"
+
+          token=$(curl -fsSL -u "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPOSITORY}:pull,push" | jq -r '.token')
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "Failed to obtain Docker Hub registry token"
+            exit 1
+          fi
+
+          for attempt in {1..5}; do
+            response_file=$(mktemp)
+            http_code=$(curl -sS -o "$response_file" -w "%{http_code}" \
+              -X PUT \
+              -H "Authorization: Bearer $token" \
+              -H "Content-Type: application/vnd.docker.distribution.manifest.list.v2+json" \
+              --data-binary "@$manifest_file" \
+              "https://registry-1.docker.io/v2/${REPOSITORY}/manifests/${TAG}") || http_code="000"
+
+            if [[ "$http_code" =~ ^2 ]]; then
+              echo "Published ${REPOSITORY}:${TAG}"
+              exit 0
+            fi
+
+            echo "Manifest push for $TAG failed with HTTP $http_code"
+            cat "$response_file"
+            if [[ "$http_code" != "429" && ! "$http_code" =~ ^5 ]]; then
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 60))
+            echo "Manifest push for $TAG failed on attempt $attempt; retrying in ${sleep_seconds}s"
+            sleep "$sleep_seconds"
           done
 
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${TAG}" \
-            "${refs[@]}"
+          echo "Manifest push for $TAG failed after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- Move build/merge shell inputs from direct `run:` template interpolation into environment variables.
- Export each build's complete image descriptor from `docker/build-push-action` metadata instead of only an empty digest marker.
- Publish multi-architecture manifests directly through the Docker Registry API from those descriptors, with descriptor-count validation and retry/backoff for transient registry failures.
- Serialize manifest publication and remove the unnecessary BuildKit setup from merge jobs.

## Why
PR #2 fixed the original disk exhaustion by splitting per-platform builds, but the follow-up workflow run still failed in the merge phase. The failed jobs all hit Docker Hub `429 Too Many Requests` while `docker buildx imagetools create` re-read pushed digest manifests; several merge jobs started at the same time, and each one also booted a BuildKit builder. This PR removes that failing read path and reduces Docker Hub pressure during manifest publication.

This also covers the CodeRabbit review gap from PR #2: CodeRabbit resolved its first actionable thread, then reported a review limit before a complete follow-up pass on the final PR #2 commit.

## Test plan
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/nextcloud-docker.yml"); puts "workflow yaml ok"'`
- Extracted all workflow `run:` scripts and ran `bash -n`.
- `git diff --check`
- Simulated descriptor JSON manifest-list generation with `jq -s`.
