### PR TITLE
ci: follow Docker Hub registry redirects

### DIFF
--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -48,7 +48,7 @@ jobs:
             local url="$2"
             local output_file="$3"
             local http_code
-            http_code=$(curl -sS -o "$output_file" -w "%{http_code}" \
+            http_code=$(curl -sSL -o "$output_file" -w "%{http_code}" \
               -H "Authorization: Bearer $token" \
               -H "Accept: $accept" \
               "$url") || http_code="000"


### PR DESCRIPTION
## Summary
- Follow Docker Hub registry redirects in the workflow's authenticated registry GET helper.

## Why
The first workflow run after PR #4 failed in `detect` before building. The registry request for the stored image config blob returned HTTP 307 from Docker Hub:

`Docker Hub registry request failed with HTTP 307: https://registry-1.docker.io/v2/***/nextcloud/blobs/sha256:...`

Config blob reads are expected to redirect to backing storage. The helper should follow those redirects instead of treating them as fatal.

## Test plan
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/nextcloud-docker.yml"); puts "workflow yaml ok"'`
- Extracted all workflow `run:` scripts and ran `bash -n`.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build workflow configuration to improve HTTP redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->