### PR TITLE
ci: use Docker Hub tag API during detection

### DIFF
--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -37,19 +37,42 @@ jobs:
           }
 
           build_combinations=()
-          upstream_tags=$(curl -fsSL "https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=100")
-          own_tags=$(curl -fsSL "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/nextcloud/tags?page_size=100" || echo '{"results":[]}')
+          fetch_tags() {
+            local url="$1"
+            local aggregate_file
+            aggregate_file=$(mktemp)
+            echo '{"results":[]}' > "$aggregate_file"
 
-          mapfile -t tag_records < <(jq -c '.results[] | select(.name | test("^[0-9]") | not)' <<< "$upstream_tags")
+            while [ -n "$url" ] && [ "$url" != "null" ]; do
+              local page_file
+              page_file=$(mktemp)
+              curl -fsSL "$url" -o "$page_file"
+              jq -s '{results: (.[0].results + .[1].results)}' "$aggregate_file" "$page_file" > "${aggregate_file}.next"
+              mv "${aggregate_file}.next" "$aggregate_file"
+              url=$(jq -r '.next // ""' "$page_file")
+            done
+
+            cat "$aggregate_file"
+          }
+
+          upstream_tags=$(fetch_tags "https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=100")
+          own_tags=$(fetch_tags "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/nextcloud/tags?page_size=100" || echo '{"results":[]}')
+
+          # README promises non-versioned tags only; official versioned tags start with a number.
+          mapfile -t tag_records < <(jq -c '.results[] | select((.tag_status // "active") == "active") | select(.name | test("^[0-9]+([.-].*)?$") | not)' <<< "$upstream_tags")
 
           for tag_record in "${tag_records[@]}"; do
             tag=$(jq -r '.name' <<< "$tag_record")
             base_digest=$(jq -r '.digest // ""' <<< "$tag_record")
             upstream_last_updated=$(jq -r '.last_updated // ""' <<< "$tag_record")
-            own_last_updated=$(jq -r --arg tag "$tag" '.results[]? | select(.name == $tag) | .last_updated // ""' <<< "$own_tags" | head -n 1)
+            own_last_updated=$(jq -r --arg tag "$tag" '.results[]? | select((.tag_status // "active") == "active") | select(.name == $tag) | .last_updated // ""' <<< "$own_tags" | head -n 1)
 
-            if [ -z "$base_digest" ] || [ "$base_digest" = "null" ] || [ -z "$upstream_last_updated" ] || [ "$upstream_last_updated" = "null" ]; then
-              echo "Docker Hub tag metadata is incomplete for nextcloud:$tag"
+            if [ -z "$base_digest" ] || [ "$base_digest" = "null" ]; then
+              echo "Skipping tag: $tag (Docker Hub tag metadata has no digest)"
+              continue
+            fi
+            if [ -z "$upstream_last_updated" ] || [ "$upstream_last_updated" = "null" ]; then
+              echo "Docker Hub tag metadata is missing last_updated for nextcloud:$tag"
               echo "$tag_record"
               exit 1
             fi

--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -11,17 +11,10 @@ jobs:
     outputs:
       build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
     steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Detect image:tag combinations with ffmpeg support
         id: set-matrix
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           supports_ffmpeg() {
             local arch="$1"
@@ -43,106 +36,54 @@ jobs:
             return 1
           }
 
-          registry_get() {
-            local accept="$1"
-            local url="$2"
-            local output_file="$3"
-            local http_code
-            http_code=$(curl -sSL -o "$output_file" -w "%{http_code}" \
-              -H "Authorization: Bearer $token" \
-              -H "Accept: $accept" \
-              "$url") || http_code="000"
-
-            if [[ "$http_code" =~ ^2 ]]; then
-              return 0
-            fi
-            if [ "$http_code" = "404" ]; then
-              return 1
-            fi
-
-            echo "Docker Hub registry request failed with HTTP $http_code: $url"
-            cat "$output_file"
-            exit 1
-          }
-
           build_combinations=()
-          # Get available tags and filter out versioned ones
-          tags=$(curl -fsSL "https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=100" | \
-            jq -r '.results[].name | select(test("^[0-9]") | not)')
+          upstream_tags=$(curl -fsSL "https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=100")
+          own_tags=$(curl -fsSL "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/nextcloud/tags?page_size=100" || echo '{"results":[]}')
 
-          token=$(curl -fsSL -u "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
-            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${DOCKERHUB_USERNAME}/nextcloud:pull" | jq -r '.token')
-          if [ -z "$token" ] || [ "$token" = "null" ]; then
-            echo "Failed to obtain Docker Hub registry token"
-            exit 1
-          fi
+          mapfile -t tag_records < <(jq -c '.results[] | select(.name | test("^[0-9]") | not)' <<< "$upstream_tags")
 
-          for tag in $tags; do
-            if ! manifest=$(docker manifest inspect "nextcloud:$tag" 2>/tmp/nextcloud-manifest-error); then
-              echo "Failed to inspect nextcloud:$tag"
-              cat /tmp/nextcloud-manifest-error
+          for tag_record in "${tag_records[@]}"; do
+            tag=$(jq -r '.name' <<< "$tag_record")
+            base_digest=$(jq -r '.digest // ""' <<< "$tag_record")
+            upstream_last_updated=$(jq -r '.last_updated // ""' <<< "$tag_record")
+            own_last_updated=$(jq -r --arg tag "$tag" '.results[]? | select(.name == $tag) | .last_updated // ""' <<< "$own_tags" | head -n 1)
+
+            if [ -z "$base_digest" ] || [ "$base_digest" = "null" ] || [ -z "$upstream_last_updated" ] || [ "$upstream_last_updated" = "null" ]; then
+              echo "Docker Hub tag metadata is incomplete for nextcloud:$tag"
+              echo "$tag_record"
               exit 1
             fi
 
-            # Get the current base image digest
-            base_digest=$(echo "$manifest" | jq -r '.manifests[0].digest // ""')
-
-            # Get the base digest label stored in our image (if it exists)
-            our_manifest_file=$(mktemp)
-            stored_base_digest=""
-            if registry_get \
-              "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json" \
-              "https://registry-1.docker.io/v2/${DOCKERHUB_USERNAME}/nextcloud/manifests/$tag" \
-              "$our_manifest_file"; then
-              manifest_digest=$(jq -r '.manifests[0].digest // ""' "$our_manifest_file")
-              if [[ -n "$manifest_digest" && "$manifest_digest" != "null" ]]; then
-                child_manifest_file=$(mktemp)
-                registry_get \
-                  "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json" \
-                  "https://registry-1.docker.io/v2/${DOCKERHUB_USERNAME}/nextcloud/manifests/$manifest_digest" \
-                  "$child_manifest_file"
-                config_digest=$(jq -r '.config.digest // ""' "$child_manifest_file")
-              else
-                config_digest=$(jq -r '.config.digest // ""' "$our_manifest_file")
-              fi
-
-              if [[ -n "$config_digest" && "$config_digest" != "null" ]]; then
-                config_blob_file=$(mktemp)
-                registry_get \
-                  "application/vnd.docker.container.image.v1+json, application/vnd.oci.image.config.v1+json" \
-                  "https://registry-1.docker.io/v2/${DOCKERHUB_USERNAME}/nextcloud/blobs/$config_digest" \
-                  "$config_blob_file"
-                stored_base_digest=$(jq -r '.config.Labels["org.opencontainers.image.base.digest"] // ""' "$config_blob_file")
-              fi
+            if [[ -n "$own_last_updated" && "$own_last_updated" != "null" ]] &&
+              [[ "$own_last_updated" > "$upstream_last_updated" || "$own_last_updated" == "$upstream_last_updated" ]]; then
+              echo "Skipping tag: $tag (target image is newer than upstream)"
+              continue
             fi
 
-            # Only rebuild if base image has changed or we don't have the image yet
-            if [[ -n "$base_digest" && "$base_digest" != "$stored_base_digest" ]]; then
-              echo "Processing tag: $tag"
-              # Get all architectures from manifest
-              all_archs=$(echo "$manifest" | jq -r '.manifests[].platform | select(.os != "unknown" and .architecture != "unknown") | .os + "/" + .architecture + if .variant then "/" + .variant else "" end' | sort | uniq)
+            echo "Processing tag: $tag"
+            # Get all architectures from Docker Hub tag metadata.
+            all_archs=$(jq -r '.images[]? | select(.status == "active") | select(.os != "unknown" and .architecture != "unknown") | .os + "/" + .architecture + if .variant then "/" + .variant else "" end' <<< "$tag_record" | sort | uniq)
 
-              # Determine if alpine or debian based
-              is_alpine="false"
-              if echo "$tag" | grep -q "alpine"; then
-                is_alpine="true"
+            # Determine if alpine or debian based
+            is_alpine="false"
+            if echo "$tag" | grep -q "alpine"; then
+              is_alpine="true"
+            fi
+
+            # Filter architectures based on known ffmpeg package availability.
+            supported_archs=()
+            for arch in $all_archs; do
+              if supports_ffmpeg "$arch" "$is_alpine"; then
+                supported_archs+=("$arch")
               fi
+            done
 
-              # Filter architectures based on known ffmpeg package availability.
-              supported_archs=()
-              for arch in $all_archs; do
-                if supports_ffmpeg "$arch" "$is_alpine"; then
-                  supported_archs+=("$arch")
-                fi
-              done
-
-              if [ ${#supported_archs[@]} -gt 0 ]; then
-                platforms=$(IFS=,; echo "${supported_archs[*]}")
-                build_combinations+=("{\"tag\":\"$tag\",\"platforms\":\"$platforms\",\"base_digest\":\"$base_digest\"}")
-                echo "  → $tag: ${#supported_archs[@]} architectures"
-              else
-                echo "  → $tag: No supported architectures, skipping"
-              fi
+            if [ ${#supported_archs[@]} -gt 0 ]; then
+              platforms=$(IFS=,; echo "${supported_archs[*]}")
+              build_combinations+=("$(jq -cn --arg tag "$tag" --arg platforms "$platforms" --arg base_digest "$base_digest" '{tag:$tag,platforms:$platforms,base_digest:$base_digest}')")
+              echo "  → $tag: ${#supported_archs[@]} architectures"
+            else
+              echo "  → $tag: No supported architectures, skipping"
             fi
           done
           echo "build_matrix={\"include\":[$(IFS=,; echo "${build_combinations[*]}")]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- replace Docker CLI manifest inspection in detection with Docker Hub tags API metadata
- skip target tags whose Docker Hub metadata is already newer than upstream
- keep the build matrix to only stale/missing tags, avoiding pull-counted registry reads during detection

## Validation
- ruby YAML parse
- bash -n over workflow run scripts
- local detect dry run with DOCKERHUB_USERNAME=realies emitted one production-apache matrix entry
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined tag-detection and matrix generation by switching to Docker Hub tag APIs.
  * Simplified authentication: no DockerHub token required during detection.
  * Filters upstream tags to active, non-numeric names and skips images already up to date.
  * Derives supported platforms (including alpine vs non-alpine) from upstream metadata and validates required metadata before including tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->