### PR TITLE
ci: pin Node 24 compatible actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/nextcloud-docker.yml
+++ b/.github/workflows/nextcloud-docker.yml
@@ -122,19 +122,19 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Build Platforms and Publish Manifest
         env:


### PR DESCRIPTION
## Summary
- update GitHub Actions dependencies to Node 24 compatible releases
- pin actions to exact release tags instead of moving major tags
- add Dependabot weekly updates for GitHub Actions

## Validation
- YAML parse for workflow and Dependabot config
- bash -n over workflow run scripts
- git diff --check

Note: repository allow_auto_merge is currently false, so Dependabot PR auto-merge still needs repo/ruleset configuration outside dependabot.yml.